### PR TITLE
Fix Y-axis tick labels computation by dropping decimal part

### DIFF
--- a/main.js
+++ b/main.js
@@ -76,7 +76,7 @@ function plotPerformance(comparedStats, rankOnly = false) {
                 yAxes: [{
                     ticks: {
                         callback: function (value, index, values) {
-                            return rankOnly ? value : `${value * 100}%`
+                            return rankOnly ? value : `${~~(value * 100)}%`
                         }
                     }
                 }]


### PR DESCRIPTION
Fixes #1

When applied long decimal "tails" won't leak into Y-axis percentage values.

![image](https://user-images.githubusercontent.com/8686631/70574434-c3b58700-1bac-11ea-9563-c28ed32f07f4.png)
