### PR TITLE
Fix percentage calcs base

### DIFF
--- a/main.js
+++ b/main.js
@@ -99,9 +99,9 @@ function generateStats(totalUsers = false, rankOnly = false) {
             return [
                 val.day,
                 val.stats[0].rank,
-                val.stats[0].rank / partTwoTotal,
+                val.stats[0].rank / partOneTotal,
                 val.stats[1].rank,
-                val.stats[1].rank / partOneTotal
+                val.stats[1].rank / partTwoTotal
             ]
     }).sort((a, b) => a[0] - b[0])
 


### PR DESCRIPTION
Quick debug showed that `partOneTotal` is calculated appropriately including both gold and silver stars counts. `partTwoTotal` includes only golds count.
The problem was that participant's ranks were rated against totals in wrong order.
Part 1 participant's rank should be rated against `partOneTotal` and part 2 participant's rank should be rated against `partTwoTotal`.

Please double-check this.

Fixes #3